### PR TITLE
Actix rt 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["serial_test", "serial_test_derive", "serial_test_test"]
+

--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/palfrey/serial_test/"
 readme = "README.md"
 categories = ["development-tools::testing"]
 
+[features]
+actix-rt2 = ["serial_test_derive/actix-rt2"]
+
+
 [dependencies]
 lazy_static = "1.2"
 parking_lot = ">= 0.10, < 0.12"

--- a/serial_test_derive/Cargo.toml
+++ b/serial_test_derive/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["development-tools::testing"]
 [lib]
 proc-macro = true
 
+[features]
+actix-rt2 = []
+
 [dependencies]
 quote = "1.0"
 syn = { version="1.0", features=["full"] }

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -126,7 +126,13 @@ fn serial_core(
         true => quote!{ #[test] },
     };
 
+    #[cfg(not(feature = "actix-rt2"))]
     let reactor = reactor
+        .map(|_r| quote!{tokio::runtime::Runtime::new().unwrap().block_on})
+        .unwrap_or(quote!{actix_rt::System::new("test").block_on});
+
+    #[cfg(feature = "actix-rt2")]
+        let reactor = reactor
         .map(|_r| quote!{tokio::runtime::Runtime::new().unwrap().block_on})
         .unwrap_or(quote!{actix_rt::System::new().block_on});
 
@@ -208,6 +214,7 @@ fn parse_reactor(attrs: &Vec<TokenTree>, g: &Group) -> Ident {
         _ => panic!("Expected a single {{reactor_name}} as argument, got {:?}", attrs),
     }
 }
+
 
 #[test]
 fn test_serial() {

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -128,7 +128,7 @@ fn serial_core(
 
     let reactor = reactor
         .map(|_r| quote!{tokio::runtime::Runtime::new().unwrap().block_on})
-        .unwrap_or(quote!{actix_rt::System::new("test").block_on});
+        .unwrap_or(quote!{actix_rt::System::new().block_on});
 
     let gen = if let Some(ret) = return_type {
         match asyncness {


### PR DESCRIPTION
`actix-rt` in versions above `2.x` don't initialize `System` with name.

Added feature flag to switch between `actix-rt` versions